### PR TITLE
Honor server-owned review requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flowchart LR
 
 1. **Brainstorm** with your coding agent until the shape of the change is clear.
 2. **Plan** the work in enough detail for someone else to understand and build it.
-3. **Approve** — the Plan is cleared under your workspace's review policy. For team work, that means another person reviews it before implementation begins.
+3. **Approve** — the Plan is cleared under your workspace's saved review policy. Plans marked `not_required` proceed without Review; plans marked `required` need another person's approval before implementation begins.
 4. **Run** the Plan with your coding agent.
 5. **Check** the Pull request against what the team agreed. Where they differ, fix the code, accept the difference on the record, or take the work back to the Plan.
 
@@ -41,7 +41,7 @@ flowchart LR
 
 > No code until the Plan is agreed.
 
-For team work, another person reviews the Plan before implementation starts. Solo users can continue after submitting their Plan without pretending to review their own work.
+Until's saved policy decides whether a Plan needs Review. A confirmed `not_required` Plan proceeds without Review; a confirmed `required` Plan needs another person's approval before implementation starts.
 
 The argument behind the rule is our manifesto, [AI Is Not Your Peer](https://www.notyourpeer.com/): reviewing an agent's Pull request is auditing a machine, and the Plan is the part a person actually decided.
 

--- a/hooks/prompt-reminder
+++ b/hooks/prompt-reminder
@@ -18,7 +18,8 @@ saved plan says peer review is not required. On a fresh implementation ask,
 brainstorming MUST be the first stage skill — never probe writing-a-good-plan
 first. Iron Rule: no
 implementation code before the plan upload is confirmed and Until's saved
-review policy clears it; team plans require another human's approved verdict.
+review policy clears it; review-required plans need another human's approved
+verdict.
 When clearance first appears, report implementation ready and STOP; only a
 fresh post-clearance “implement now” instruction starts edits. Build is neither
 submission nor implementation consent, and a denied edit is a stop condition

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -38,7 +38,7 @@ using_until_escaped=$(escape_for_json "$using_until_content")
 
 gate_id_context=""
 if [ -n "$convo_id" ]; then
-  gate_id_context="\n\n**This session's human-run bypass command: touch ~/.until/state/skip-${convo_id}** — use this ONLY after your partner explicitly says “Don’t use the Until Loop for this.” Never execute or propose it as solo approval, sign-off, or an ordinary review path. Quote their instruction, explain once what they waive, then give them this exact command to run in their own terminal. Never chain it, vary it, create the file yourself, or expose this plumbing otherwise."
+  gate_id_context="\n\n**This session's human-run bypass command: touch ~/.until/state/skip-${convo_id}** — use this ONLY after your partner explicitly says “Don’t use the Until Loop for this.” Never execute or propose it as a review substitute, sign-off, or an ordinary review path. Quote their instruction, explain once what they waive, then give them this exact command to run in their own terminal. Never chain it, vary it, create the file yourself, or expose this plumbing otherwise."
 fi
 
 session_context="You have Until.\n\nBelow is the full 'until:using-until' routing guide. For later stages, use the matching skill.\n\n${using_until_escaped}${gate_id_context}"

--- a/hooks/until-commit-gate
+++ b/hooks/until-commit-gate
@@ -11,7 +11,8 @@ traffic). Two enforcement modes:
    file edits and unrecognized shell execution. Read-only inspection and the
    short `pending_upload` stage remain available for the upload itself. Once
    `get_plan` confirms submission, shell enforcement closes again. A plan is
-   clear when peer review is not required or an approved verdict has landed.
+   clear only when that call confirms `not_required`, or `required` with an
+   approved lifecycle.
 
 2. Default-closed repos: a repo containing a `.until-method` marker file at
    its root follows the Until method for implementation changes. File edits
@@ -382,10 +383,13 @@ def main():
     in_flight = setup_required or (has_valid_plan and not build_allowed)
     skipped = os.path.exists(skip_path)
     plan_id = tracked_plan_id if has_valid_plan else "unavailable"
-    solo_policy_pending = (
+    review_requirement = (state or {}).get("review_requirement")
+    review_not_required_pending = (
         in_flight
-        and (state or {}).get("review_requirement") == "not_required"
-        and (state or {}).get("review_policy_reason") == "no_other_human"
+        and review_requirement == "not_required"
+    )
+    review_requirement_unrecognized = (
+        in_flight and review_requirement not in ("required", "not_required")
     )
 
     # agent_message is read by the model; user_message is shown VERBATIM in the
@@ -415,7 +419,7 @@ def main():
             f"Until: plan {plan_id}'s upload authorization expired — retry the "
             "submission to continue."
         )
-    elif solo_policy_pending:
+    elif review_not_required_pending:
         in_flight_agent_msg = (
             f"UNTIL GATE: plan {plan_id} does not require peer review, but its upload "
             "has not been confirmed through get_plan yet. Run the exact upload command "
@@ -426,6 +430,17 @@ def main():
         in_flight_user_msg = (
             f"Until: plan {plan_id} is still saving — building starts after I confirm "
             "it landed."
+        )
+    elif review_requirement_unrecognized:
+        in_flight_agent_msg = (
+            f"UNTIL GATE: plan {plan_id} has no recognized saved review "
+            "requirement. Implementation remains blocked. Confirm the current plan "
+            "with get_plan; do not infer policy from reasons, membership, reviewer "
+            "availability, or lifecycle fields, and do not request review."
+        )
+        in_flight_user_msg = (
+            f"Until has not confirmed a recognized review requirement for plan "
+            f"{plan_id} — building stays paused."
         )
     elif changes_requested:
         in_flight_agent_msg = (
@@ -464,8 +479,9 @@ def main():
         "conversation has none. No edits, "
         "no commits until then. The path forward is the method itself: load "
         "`brainstorming` to agree the shape with your partner, `writing-a-good-plan` "
-        "to draft it, and submit_plan. A solo plan proceeds after its upload is "
-        "confirmed; a team plan proceeds after another human approves it. A direct "
+        "to draft it, and submit_plan. A review-not-required plan proceeds after "
+        "its upload is confirmed; a review-required plan proceeds after another "
+        "human approves it. A direct "
         "instruction to make the change is the START of that "
         "conversation, not permission to bypass it. If your partner says "
         "“Don’t use the Until Loop for this.”, THEY must run this in their own terminal: "

--- a/hooks/until-track-state
+++ b/hooks/until-track-state
@@ -257,7 +257,8 @@ def main():
         # upload. When Until returns an upload instruction, reopen the short
         # pending_upload shell window so the body curl can run; get_plan after
         # upload closes it again. Title-only updates have no upload and stay
-        # submitted / gated. Team plans then need a fresh verdict; solo reopen.
+        # submitted / gated. Required plans need a fresh verdict; plans whose
+        # saved requirement is not_required can reopen after confirmation.
         stage = "pending_upload" if opens_upload_window(result) else "submitted"
         if state is None:
             pid = find_plan_id(result)
@@ -337,9 +338,13 @@ def main():
             if plan_status(result) == "pending_upload":
                 state["stage"] = "pending_upload"
                 replace_upload_authorization(state, result, retain_existing=True)
-            elif policy == ("not_required", "no_other_human"):
+            elif policy and policy[0] == "not_required":
                 state["stage"] = "review_not_required"
-            elif current_lifecycle_stage(result) == "approved":
+            elif (
+                policy
+                and policy[0] == "required"
+                and current_lifecycle_stage(result) == "approved"
+            ):
                 state["stage"] = "approved"
             elif current_lifecycle_stage(result) == "changes_requested":
                 state["stage"] = "changes_requested"

--- a/skills/checking-plan-differences/SKILL.md
+++ b/skills/checking-plan-differences/SKILL.md
@@ -34,8 +34,9 @@ and the Plan claim it maps to.
 2. **Acknowledge it.** If the difference is intentional and correct, an
    authorized person records a genuine reason against its Difference slug.
 3. **Fix the Plan.** If the difference reveals that the Plan was wrong or
-   incomplete, call `update_plan`, complete the required Review again, and let
-   the next Plan check compare against the corrected Plan.
+   incomplete, call `update_plan`, finish the upload, and confirm it with
+   `get_plan`. `not_required` needs no Review; `required` needs fresh human
+   approval. Then let the next Plan check compare against the corrected Plan.
 
 ## Bias toward fixing
 
@@ -45,7 +46,7 @@ the Plan check outcome without addressing the gap. If in doubt, resolve it.
 ## Done means
 
 Every Plan difference is resolved, acknowledged with a Difference slug and
-reason, or closed by a reviewed Plan update, and the Plan check outcome is
+reason, or closed by a cleared Plan update, and the Plan check outcome is
 successful. The Pull request is ready for implementation-quality review.
 
 ## Red Flags — STOP

--- a/skills/getting-a-review/SKILL.md
+++ b/skills/getting-a-review/SKILL.md
@@ -24,14 +24,12 @@ review.
 
 Call `get_plan` and inspect the returned `review` object:
 
-- `requirement: not_required`, `policy_reason: no_other_human` — stop using
-  this skill. Do not request review, run a review subagent, or ask for a local
-  sign-off. Tell your partner the plan is cleared and implementation is ready,
-  then STOP. Load `implementing-a-plan` only after a fresh “implement now”
-  instruction.
+- `requirement: not_required` — stop. Regardless of `policy_reason` or
+  available humans, do not request review or another sign-off. Report
+  implementation ready, then STOP for a fresh “implement now.”
 - `requirement: required` — continue below.
-- Missing policy fields — do not guess that the workspace is solo. Treat the
-  plan as requiring review and explain that Until has not cleared it.
+- Missing or unrecognized requirement — report not cleared and stop. Do not
+  infer from `policy_reason` or membership, and do not request review.
 
 ## Send it to another human
 
@@ -72,9 +70,12 @@ Call `get_plan` again:
 
 If the assigned reviewer is no longer available, choose another active human.
 If none is available for a plan whose saved policy is `required`, say that the
-plan still requires peer review and stop. Do not invent a solo fallback: review
-policy is stamped when the plan is created, and existing plans remain on their
-saved policy.
+plan still requires peer review and stop. Reviewer availability does not change
+the saved requirement.
+
+Only when asked how Until reviews work or are enabled, say the Until team
+manages review requirements and direct them to the team. Do not surface this
+during normal routing.
 
 ## Choosing not to use the Until Loop
 
@@ -87,8 +88,8 @@ visibly unreviewed.
 
 | Thought | Reality |
 |---|---|
-| "It's a solo workspace, so I'll run a subagent review" | The saved policy decides. `not_required` skips this stage; `required` needs another human. |
-| "The subagent recommended approve" | A model recommendation is not a human verdict and is not part of the solo flow. |
+| "There are teammates, so review must be required" | Membership does not decide. The saved requirement does. |
+| "The subagent recommended approve" | A model recommendation is not a human verdict. |
 | "They said it looks good in chat" | Chat creates no review record. The assigned reviewer records their own verdict. |
 | "Revise, then approve is basically approval" | Revise is not approval. Update the plan and get a fresh verdict. |
 | "A denied source edit means the plan cannot be revised" | Product code stays paused; the canonical plan and Until scratch space remain editable. |

--- a/skills/implementing-a-plan/SKILL.md
+++ b/skills/implementing-a-plan/SKILL.md
@@ -24,13 +24,13 @@ instruction.
 
 The plan clears in exactly one of these ways:
 
-- Peer review is not required: `review.requirement: not_required` with
-  `policy_reason: no_other_human`.
+- Peer review is not required: `review.requirement: not_required`.
 - Required review has another human's approved verdict.
 
 Verify with `get_plan` after upload. Missing policy, unfinished uploads, pending
 or negative verdicts, chat approval, and Build do not clear it. Never record a
-verdict on a plan you wrote.
+verdict on a plan you wrote. `policy_reason` and workspace membership never
+control clearance.
 
 **Clearance makes implementation available; it does not start it.** After
 first observing it, report readiness and STOP for a fresh “implement now”.
@@ -71,7 +71,7 @@ Cursor Cloud reports the contradiction and stops; the original Until Loop
 updates the Plan. Local sessions pause, explain what reality contradicted, update with
 `update_plan`, finish the upload, and confirm with `get_plan`:
 
-- A `not_required / no_other_human` plan can become ready again immediately.
+- A `not_required` plan can become ready again after upload confirmation.
 - A `required` plan needs a fresh approval from another human.
 
 After either path clears, report readiness and wait for a new “implement now”

--- a/skills/using-until/SKILL.md
+++ b/skills/using-until/SKILL.md
@@ -55,9 +55,11 @@ prompt names the submitted, cleared plan and assigns work within it.
 
 Local implementation waits until upload is confirmed and `get_plan` shows:
 
-- `review.requirement: not_required` with
-  `policy_reason: no_other_human`; or
+- `review.requirement: not_required`; or
 - `review.requirement: required` with an approved verdict from another human.
+
+`policy_reason` and membership never route; missing or unknown requirements do
+not clear.
 
 Chat approval, a Build-button click, a subagent recommendation, and a verdict
 recorded by the author do not clear a plan. Requested changes require

--- a/skills/writing-a-good-plan/SKILL.md
+++ b/skills/writing-a-good-plan/SKILL.md
@@ -332,11 +332,11 @@ said to submit (§4):
 3. Run the shell command it returns to upload the plan body.
 4. Call `get_plan` to confirm the plan landed and read its server-owned
    `review.requirement`.
-5. If it is `not_required` with reason `no_other_human`, do not request review
-   or run a fresh-context reviewer. Tell your partner the plan is cleared and
-   implementation is ready, then STOP. Wait for a fresh “implement now”
-   instruction before loading `implementing-a-plan`.
+5. If it is `not_required`, do not request review or another reviewer,
+   regardless of `policy_reason` or membership. Report implementation ready,
+   then STOP for a fresh “implement now” before loading `implementing-a-plan`.
 6. If it is `required`, load `getting-a-review`.
+7. Otherwise, report not cleared and STOP; never infer from `policy_reason`.
 
 ### Source Control setup required
 


### PR DESCRIPTION
## Summary
- route plan clearance from the saved `review.requirement`, independent of diagnostic policy reasons or workspace membership
- keep hooks, skills, and public documentation aligned on `not_required` versus `required` behavior
- preserve Until-only branding and plugin version `0.1.0`
- direct compatibility patch ahead of [ENG-6075](https://linear.app/overmind/issue/ENG-6075/move-ide-plugins-into-monorepo-and-create-release-process); retain it when the monorepo becomes the source of truth

## Test plan
- [x] Exercise `not_required` with legacy, disabled-policy, unknown, and absent reasons
- [x] Exercise `required` with approved, pending, and changes-requested lifecycle states
- [x] Confirm missing or unknown requirements remain blocked
- [x] Validate Python and shell hook syntax
- [x] Confirm no Brent names or internal hosts appear in the public tree
- [x] Confirm all plugin manifests remain at version `0.1.0`

Made with [Cursor](https://cursor.com)